### PR TITLE
Don't treat failed tests as "error" on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Run test
       run: bundle exec rake
+      continue-on-error: ${{ (matrix.os == 'macos-latest')  }}
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It seems that macos-latest runners don't stable now. Ref:

* https://github.com/actions/runner-images/issues/8642
* https://github.com/actions/runner-images/issues/8697