### PR TITLE
Temporary disable CI on mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           - '3.3'
         os:
           - ubuntu-latest
-          - macos-latest
+ #         - macos-latest
     env:
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: YES
 


### PR DESCRIPTION
It seems that tests don't work since mac OS 13. I'll check it later.