### PR TITLE
Add `x86_64-linux-musl` for CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -55,6 +56,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
+  x86_64-linux-gnu
 
 DEPENDENCIES
   debug


### PR DESCRIPTION
Ref: https://github.com/ffi/ffi/issues/1105