### PR TITLE
Remove `wait_until_startup` option

### DIFF
--- a/lib/watchcat.rb
+++ b/lib/watchcat.rb
@@ -14,7 +14,6 @@ module Watchcat
       recursive: true,
       force_polling: false,
       poll_interval: nil,
-      wait_until_startup: false,
       filters: {},
       debounce: -1,
       &block
@@ -25,7 +24,6 @@ module Watchcat
           recursive: recursive,
           force_polling: force_polling,
           poll_interval: poll_interval,
-          wait_until_startup: wait_until_startup,
           filters: filters,
           debounce: debounce,
           block: block

--- a/lib/watchcat/executor.rb
+++ b/lib/watchcat/executor.rb
@@ -2,12 +2,11 @@ require_relative "event"
 
 module Watchcat
   class Executor
-    def initialize(paths, recursive:, force_polling:, poll_interval:, wait_until_startup:, filters:, debounce:, block:)
+    def initialize(paths, recursive:, force_polling:, poll_interval:, filters:, debounce:, block:)
       @paths = paths
       @recursive = recursive
       @force_polling = force_polling
       @poll_interval = poll_interval
-      @wait_until_startup = wait_until_startup
       @filters = filters || {}
       @debounce = debounce
       @block = block
@@ -21,11 +20,6 @@ module Watchcat
       @watch_thread = Thread.new do
         Thread.current.name = "watchcat-watcher"
         start_watching
-      end
-
-      # If wait_until_startup is true, give the thread a moment to start
-      if @wait_until_startup
-        sleep 0.1
       end
 
       at_exit do

--- a/test/watchcat/kind_test.rb
+++ b/test/watchcat/kind_test.rb
@@ -19,7 +19,7 @@ class Watchcat::KindTest < Minitest::Test
 
     events = []
     sleep 0.2
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
     sleep 0.2
     FileUtils.remove(file)
     sleep 0.2
@@ -44,7 +44,7 @@ class Watchcat::KindTest < Minitest::Test
 
     events = []
     sleep 0.2
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
     sleep 0.2
     FileUtils.remove_dir(dir)
     sleep 0.2
@@ -64,7 +64,7 @@ class Watchcat::KindTest < Minitest::Test
 
   def test_create_file
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
     sleep 0.2
     FileUtils.touch(File.join(@tmpdir, "a.txt"))
     sleep 0.2
@@ -85,7 +85,7 @@ class Watchcat::KindTest < Minitest::Test
 
   def test_create_file_with_debonuce
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, debounce: 100, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false, debounce: 100) { |e| events << e }
     sleep 0.2
     FileUtils.touch(File.join(@tmpdir, "a.txt"))
     sleep 0.4
@@ -99,7 +99,7 @@ class Watchcat::KindTest < Minitest::Test
 
   def test_create_directory
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
     sleep 0.2
     dir = File.join(@tmpdir, "dir")
     Dir.mkdir(dir)
@@ -116,7 +116,7 @@ class Watchcat::KindTest < Minitest::Test
 
   def test_create_directory_with_debounce
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, debounce: 100, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false, debounce: 100) { |e| events << e }
     sleep 0.2
     dir = File.join(@tmpdir, "dir")
     Dir.mkdir(dir)
@@ -135,7 +135,7 @@ class Watchcat::KindTest < Minitest::Test
 
     events = []
     sleep 0.2
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
     sleep 0.2
     File.rename(file, new_file)
     sleep 0.2
@@ -178,7 +178,7 @@ class Watchcat::KindTest < Minitest::Test
 
     events = []
     sleep 0.2
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
     sleep 0.2
     system("echo 'a' >> #{file}", exception: true)
     sleep 0.2
@@ -213,7 +213,7 @@ class Watchcat::KindTest < Minitest::Test
 
     events = []
     sleep 0.2
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
     sleep 0.2
     FileUtils.chmod(0644, file)
     sleep 0.2

--- a/test/watchcat_test.rb
+++ b/test/watchcat_test.rb
@@ -17,7 +17,7 @@ class WatchcatTest < Minitest::Test
 
   def test_watch_directory_without_recursive
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: false, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: false) { |e| events << e }
 
     sleep 0.2
     FileUtils.touch(File.join(@tmpdir, "a.txt"))
@@ -44,7 +44,7 @@ class WatchcatTest < Minitest::Test
 
   def test_watch_directory_with_recursive
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: true, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: true) { |e| events << e }
 
     sleep 0.2
     FileUtils.touch(File.join(@tmpdir, "a.txt"))
@@ -65,7 +65,7 @@ class WatchcatTest < Minitest::Test
 
   def test_watch_directory_with_recursive_and_debonuce
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: true, debounce: 200, wait_until_startup: true) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: true, debounce: 200) { |e| events << e }
 
     sleep 0.2
     FileUtils.touch(File.join(@tmpdir, "a.txt"))
@@ -159,7 +159,7 @@ class WatchcatTest < Minitest::Test
 
   def test_watch_with_ignore_remove
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: true, wait_until_startup: true, filters: {ignore_remove: true}) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: true, filters: {ignore_remove: true}) { |e| events << e }
 
     sleep 0.2
     FileUtils.touch(File.join(@tmpdir, "a.txt"))
@@ -186,7 +186,7 @@ class WatchcatTest < Minitest::Test
 
   def test_watch_with_ignore_remove_and_debounce
     events = []
-    @watchcat = Watchcat.watch(@tmpdir, recursive: true, debounce: 200, wait_until_startup: true, filters: {ignore_remove: true}) { |e| events << e }
+    @watchcat = Watchcat.watch(@tmpdir, recursive: true, debounce: 200, filters: {ignore_remove: true}) { |e| events << e }
 
     sleep 0.2
     FileUtils.touch(File.join(@tmpdir, "a.txt"))
@@ -205,7 +205,6 @@ class WatchcatTest < Minitest::Test
     @watchcat = Watchcat.watch(
       @tmpdir,
       recursive: true,
-      wait_until_startup: true,
       filters: {ignore_access: true}
     ) { |e| events << e }
 
@@ -228,7 +227,6 @@ class WatchcatTest < Minitest::Test
     @watchcat = Watchcat.watch(
       @tmpdir,
       recursive: true,
-      wait_until_startup: true,
       filters: {ignore_create: true}
     ) { |e| events << e }
 
@@ -249,7 +247,6 @@ class WatchcatTest < Minitest::Test
     @watchcat = Watchcat.watch(
       @tmpdir,
       recursive: true,
-      wait_until_startup: true,
       filters: {ignore_modify: true}
     ) { |e| events << e }
 


### PR DESCRIPTION
This was needed when I used Drb. But, I didn't use it now.